### PR TITLE
Two small improvments on the plugin

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/PollMailboxTrigger.java
+++ b/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/PollMailboxTrigger.java
@@ -105,7 +105,7 @@ public class PollMailboxTrigger extends AbstractTrigger {
 		script = Util.replaceMacro(script, envVars);
 
 		// build properties
-		CustomProperties p = new CustomProperties(script);
+        CustomProperties p = new CustomProperties();
         p.put(Properties.host, host);
         p.put(Properties.username, username);
         p.put(Properties.password, password.getEncryptedValue());
@@ -120,6 +120,7 @@ public class PollMailboxTrigger extends AbstractTrigger {
         p.putIfBlank("mail." + cnfStoreName + ".port", cnfStoreName.toLowerCase().endsWith("s") ? "993" : "143");
         p.putIfBlank("mail.debug", "false");
         p.putIfBlank("mail.debug.auth", "false");
+        p.read(script);
         return p;
     }
 

--- a/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/utils/CustomProperties.java
+++ b/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/utils/CustomProperties.java
@@ -34,7 +34,7 @@ public class CustomProperties {
     public static CustomProperties read(String properties) {
         Properties p = new Properties();
         try {
-            if (properties != null && !"".equals(properties)) {
+            if (properties != null && !"".equals(properties.trim())) {
                 p.load(new StringReader(properties));
             }
         } catch (IOException e) {


### PR DESCRIPTION
Hi there,

Just two small improvements:
- if the "script" property has spaces only (someone might have pressed some spaces by mistake), the CustomProperties class still should recognized it as empty (.equals(""))
- the default values of the properties were being loaded AFTER loading the user-provided ones. For instance I want to get rid of the subject filter "jenkins >" and I cannot do that, because when I add the property with the empty value, this default takes over. Thus, I submit this PR to change the order in which these data is loaded: first we load the defaults, THEN we load the user-provided values.
