### PR TITLE
Fix download message/rfc822 attachments with no file name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 dist: trusty
 jdk:
-  - openjdk8
+  - openjdk7
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
+dist: trusty
 jdk:
- - oraclejdk8
+  - openjdk8
+
 sudo: required
 
 # enable codecov reporting...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+ - oraclejdk8
 sudo: required
 
 # enable codecov reporting...

--- a/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/utils/MailWrapperUtils.java
+++ b/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/utils/MailWrapperUtils.java
@@ -25,10 +25,7 @@ import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.SearchTermHelp
 import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.SearchTermHelpers.flag;
 import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.SearchTermHelpers.not;
 import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.SearchTermHelpers.receivedSince;
-import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.Stringify.BLANK;
-import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.Stringify.MULTIPART_WILDCARD;
-import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.Stringify.NEWLINE;
-import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.Stringify.stringify;
+import static org.jenkinsci.plugins.pollmailboxtrigger.mail.utils.Stringify.*;
 
 /**
  * @author Nick Grealy
@@ -169,10 +166,15 @@ public abstract class MailWrapperUtils {
                 Multipart mp = (Multipart) content;
                 for (int i = 0; i < mp.getCount(); i++) {
                     BodyPart bodyPart = mp.getBodyPart(i);
-                    if (bodyPart instanceof MimeBodyPart && isNotBlank(bodyPart.getFileName())) {
+                    if (bodyPart instanceof MimeBodyPart) {
                         MimeBodyPart mimeBodyPart = (MimeBodyPart) bodyPart;
-                        mimeBodyPart.saveFile(new File(tmpDir, mimeBodyPart.getFileName()));
-                        foundAttachments = true;
+                        if (isNotBlank(bodyPart.getFileName())) {
+                            mimeBodyPart.saveFile(new File(tmpDir, mimeBodyPart.getFileName()));
+                            foundAttachments = true;
+                        } else if (bodyPart.isMimeType(MESSAGE_RFC822)) {
+                            mimeBodyPart.saveFile(File.createTempFile(String.valueOf(System.nanoTime()), ".eml", tmpDir));
+                            foundAttachments = true;
+                        }
                     }
                 }
             }

--- a/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/utils/Stringify.java
+++ b/src/main/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/utils/Stringify.java
@@ -281,8 +281,8 @@ public abstract class Stringify {
     /* javax.mail */
 
     public static final String TEXT_WILDCARD = "text/*", TEXT_HTML = "text/html", TEXT_PLAIN = "text/plain",
-            MULTIPART_WILDCARD = "multipart/*", MULTIPART_ALTERNATIVE = "multipart/alternative", NEWLINE = "\n",
-            BLANK = "";
+            MULTIPART_WILDCARD = "multipart/*", MULTIPART_ALTERNATIVE = "multipart/alternative",
+            MESSAGE_RFC822 = "message/rfc822", NEWLINE = "\n", BLANK = "";
 
 
     /**

--- a/src/test/groovy/org/jenkinsci/plugins/pollmailboxtrigger/StepDefs.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/pollmailboxtrigger/StepDefs.groovy
@@ -116,6 +116,7 @@ public class StepDefs {
             config.username = newConf.username
             config.password = newConf.password
             config.appendScript(newConf.script)
+            config.attachments = newConf.attachments
         }
         configUpdated(config)
     }
@@ -125,7 +126,8 @@ public class StepDefs {
         plugin.setUsername(config.username)
         plugin.setPassword(config.buildPasswordSecret())
         plugin.setScript(config.script)
-        effectiveConfig = PollMailboxTrigger.initialiseDefaults(config?.host, config?.username, config?.buildPasswordSecret(), config?.script, PollMailboxTrigger.AttachmentOptions.IGNORE.name())
+        plugin.setAttachments(config.attachments)
+        effectiveConfig = PollMailboxTrigger.initialiseDefaults(config?.host, config?.username, config?.buildPasswordSecret(), config?.script, config?.attachments)
     }
 
     @When('the script')
@@ -198,7 +200,7 @@ public class StepDefs {
 
     @Then('the log is')
     public void the_log_is(String expectedLog){
-        String actualLog = logStream.toString().replaceAll(/\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} (AM|PM)/, '<date>').replaceAll(/\r\n/, '\n')
+        String actualLog = logStream.toString().replaceAll(/\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} (AM|PM|午前|午後)/, '<date>').replaceAll(/\r\n/, '\n')
 		expectedLog = expectedLog.replaceAll(/\r\n/, '\n')
         assertThat(actualLog, is(expectedLog));
     }

--- a/src/test/groovy/org/jenkinsci/plugins/pollmailboxtrigger/bdd/ConfigurationRow.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/pollmailboxtrigger/bdd/ConfigurationRow.groovy
@@ -11,6 +11,7 @@ class ConfigurationRow {
     String username
     String password
     String script
+    String attachments
 
     Secret buildPasswordSecret(){
         password ? new Secret(password) : null

--- a/src/test/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/testingTools/MessageBuilder.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/pollmailboxtrigger/mail/testingTools/MessageBuilder.groovy
@@ -102,7 +102,7 @@ Nick
                 getContentType  : { 'text/html' },
                 getAllRecipients: { ['foo3@bar.com', 'foo4@bar.com'].collect { new InternetAddress(it) } as Address[] },
                 getContent      : { files.isEmpty() ? body.toString() : buildMultipartContent(files) },
-                isMimeType      : { it.startsWith('text') }
+                isMimeType      : { it.startsWith('text') || it.startsWith("multipart")}
         ]
     }
 
@@ -126,8 +126,10 @@ Nick
     public static Multipart buildMultipartContent(List<String> files){
         Multipart multipart = new MimeMultipart()
         files.each {
-            def part = new MimeBodyPart(MessageBuilder.getResourceAsStream(it))
-            part.setFileName(it)
+            def part = new MimeBodyPart(MessageBuilder.getClassLoader().getResourceAsStream(it))
+            if (!it.startsWith("message_rfc822")){
+                part.setFileName(it)
+            }
             part.setDisposition(Part.ATTACHMENT)
             multipart.addBodyPart(part)
         }

--- a/src/test/resources/message_rfc822.txt
+++ b/src/test/resources/message_rfc822.txt
@@ -1,0 +1,20 @@
+Content-Type: message/rfc822
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment
+
+Received: from MyComputer 
+From: <foo@example.com>
+To: <foo@example.com>
+Subject: test msg
+Date: Fri, 9 Aug 2019 16:32:33 +0900
+Message-ID: <06b901d54e84$9d63f140$d82bd3c0$@gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain;
+	charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+X-Mailer: Microsoft Outlook 16.0
+Thread-Index: AQLChAekuaJ98UcUhDkT1J+MjG4I+A==
+Content-Language: ja
+
+hello
+

--- a/src/test/resources/org/jenkinsci/plugins/pollmailboxtrigger/Configuration.feature
+++ b/src/test/resources/org/jenkinsci/plugins/pollmailboxtrigger/Configuration.feature
@@ -8,7 +8,6 @@ Feature: Configuration
     When I set the configuration to
       | Host | Username | Password | Script |
     Then the effective configuration should be
-      | attachments         | IGNORE    |
       | folder              | INBOX     |
       | mail.debug          | false     |
       | mail.debug.auth     | false     |
@@ -20,8 +19,8 @@ Feature: Configuration
 
   Scenario: I want to be able to set the basic config values
     When I set the configuration to
-      | Host     | Username | Password |
-      | mail.com | morty    | chickens |
+      | Host     | Username | Password | Attachments|
+      | mail.com | morty    | chickens | IGNORE     |
     Then the effective configuration should be
       | attachments         | IGNORE    |
       | folder              | INBOX     |
@@ -39,8 +38,8 @@ Feature: Configuration
 
   Scenario: I want to be able to override the default config values
     When I set the configuration to
-      | Host | Username | Password |
-      | aaa  | bbb      | ccc      |
+      | Host | Username | Password |Attachments|
+      | aaa  | bbb      | ccc      |IGNORE     |
     And the script
     """
     mail.debug=true
@@ -81,8 +80,8 @@ Feature: Configuration
       | falsey  | false |
       | numeric | 80085 |
     When I set the configuration to
-      | Host       | Username   | Password   |
-      | aa $cat aa | bb $dog bb | cc $pig cc |
+      | Host       | Username   | Password   |Attachments|
+      | aa $cat aa | bb $dog bb | cc $pig cc |IGNORE     |
     And the script
     """
     mail.debug=$truthy
@@ -110,8 +109,8 @@ Feature: Configuration
 
   Scenario: I want to be able to clear the default config values
     When I set the configuration to
-      | Username | Password |
-      | bbb      | ccc      |
+      | Username | Password |Attachments|
+      | bbb      | ccc      |IGNORE      |
     And the script
     """
     folder=
@@ -130,8 +129,8 @@ Feature: Configuration
 
   Scenario: I want default values for IMAP
     When I set the configuration to
-      | Host     | Username | Password |
-      | mail.com | morty    | chickens |
+      | Host     | Username | Password |Attachments|
+      | mail.com | morty    | chickens |IGNORE      |
     And the script
     """
     storeName=imap
@@ -153,8 +152,8 @@ Feature: Configuration
 
   Scenario: I want default values for IMAPS
     When I set the configuration to
-      | Host     | Username | Password |
-      | mail.com | morty    | chickens |
+      | Host     | Username | Password |Attachments|
+      | mail.com | morty    | chickens |IGNORE    |
     And the script
     """
     storeName=imaps
@@ -176,8 +175,8 @@ Feature: Configuration
 
   Scenario: I want default values for POP3
     When I set the configuration to
-      | Host          | Username        | Password |
-      | pop.gmail.com | morty@gmail.com | chickens |
+      | Host          | Username        | Password |Attachments|
+      | pop.gmail.com | morty@gmail.com | chickens |IGNORE    |
     And the script
     """
     storeName=pop3
@@ -198,8 +197,8 @@ Feature: Configuration
 
   Scenario: I want default values for POP3S
     When I set the configuration to
-      | Host          | Username        | Password |
-      | pop.gmail.com | morty@gmail.com | chickens |
+      | Host          | Username        | Password |Attachments|
+      | pop.gmail.com | morty@gmail.com | chickens |IGNORE    |
     And the script
     """
     storeName=pop3s

--- a/src/test/resources/org/jenkinsci/plugins/pollmailboxtrigger/Runtime - Start Job.feature
+++ b/src/test/resources/org/jenkinsci/plugins/pollmailboxtrigger/Runtime - Start Job.feature
@@ -10,8 +10,8 @@ Feature: Runtime - Start Job
     mail.imap.connectiontimeout=1000
     """
     When I set the configuration to
-      | Host     | Username | Password |
-      | mail.com | rick     | chickens |
+      | Host     | Username | Password | Attachments |
+      | mail.com | rick     | chickens | IGNORE |
 
   # happy path
 
@@ -150,3 +150,17 @@ Feature: Runtime - Start Job
   # todo: Error occurs, shown in the logs
   # todo: Check that the email is marked as read, so that another build isn't retriggered
   # todo: test Download attachments, so taht I can use them..
+
+
+
+  Scenario: I want the attachment file which content type is message_rfc822 and not have filename to save disk,
+  So that I have access to the email attachments from the Job
+    When I set the configuration to
+      | Host     | Username | Password | Attachments |
+      | mail.com | rick     | chickens | AUTO |
+    Given the emails
+      | Subject                   | SentXMinutesAgo | IsSeenFlag | From           | Body    |Attachments            |
+      | Jenkins > Build Plugin #4 | 5               | false      | nick@email.com | nothing | message_rfc822.txt |
+    When the Plugin's polling is triggered
+    Then a Jenkins job is scheduled with quietPeriod 0 and cause '[PollMailboxTrigger] Job was triggered by email sent from nick@email.com (<a href="triggerCauseAction">log</a>)'
+    Then there are 1 saved attachments


### PR DESCRIPTION
Fixes #26

Changes proposed in this pull request:

- Save attachments that meets the following conditions.
  - Content-Type is message/rfc822 
  - Content-Disposition has no file name.
- Save file name format is [system nanotime].eml